### PR TITLE
Added the option to configure a logo in play theme (default off)

### DIFF
--- a/web/plugin/themes/play/config.php
+++ b/web/plugin/themes/play/config.php
@@ -1,14 +1,20 @@
 <?php
-// you can replace $web_title with something like
-// $theme_play_head1 = "My Awesome Corp.";
+// You can replace $web_title with a fixed text like this:
+// $theme_play_head1 = "My Awesome Corp."; 
+// Otherwise it will pick the value from configuration
 $theme_play_head1 = $web_title;
 
-// must be replaced, it exposes this file location
+// This string must be replaced, it exposes this file location
 // try something like
 // $theme_play_head2 = "Pls dont bomb my modem, peace...";
 // or just disable it
 // $theme_play_head2 = "";
 $theme_play_head2 = "Change ".__FILE__." to customize";
+
+// If you have a custom logo, you can enable it here, just change
+// the value of $theme_image to the logo filename the theme
+// images folder (i.e. default_logo.png)
+$theme_image = "";
 
 $copychar = "&copy;";
 $copyyear = date("Y");

--- a/web/plugin/themes/play/header.php
+++ b/web/plugin/themes/play/header.php
@@ -128,7 +128,15 @@
     
       <div class="content">
         <div class="page-header">
-          <h1><?php echo $theme_play_head1; ?> <small><?php echo $theme_play_head2; ?></small></h1>
+          <div style="float:left;">
+	<?php if (isset($theme_image)  &&  !empty($theme_image)) { ?>
+          <img style="vertical-align: middle;" src="plugin/themes/play/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
+          </div>
+          <div style="float:left; height: 85px; padding-left: 20px;">
+	<?php } ?>
+          <h1 style="line-height: 85px;"><?php echo $theme_play_head1; ?><small><?php echo $theme_play_head2; ?></small></h1>
+          </div>
+          <div style="clear:both;"></div> 
         </div>
         <div class="row">
           <div class="span14">


### PR DESCRIPTION
In our deployment, we need to set a logo, I've prepared a space of 85px height in which you can configure the logo.
If playsms had a deafault logo this could be set on by default.
Tell me if you want me to test this change to another theme or to adapt to a generic location.
