### PR TITLE
updates SQL install script to fill new option 'sendsms_host'

### DIFF
--- a/db/playsms.sql
+++ b/db/playsms.sql
@@ -920,7 +920,7 @@ CREATE TABLE `playsms_gatewayKannel_config` (
 
 LOCK TABLES `playsms_gatewayKannel_config` WRITE;
 /*!40000 ALTER TABLE `playsms_gatewayKannel_config` DISABLE KEYS */;
-INSERT INTO `playsms_gatewayKannel_config` VALUES (0,'kannel','/var/spool/playsms','playsms','playsms','','127.0.0.1','13131','http://localhost/playsms','31','','+0700','','',0);
+INSERT INTO `playsms_gatewayKannel_config` VALUES (0,'kannel','/var/spool/playsms','playsms','playsms','','127.0.0.1','127.0.0.1','13131','http://localhost/playsms','31','','+0700','','',0);
 /*!40000 ALTER TABLE `playsms_gatewayKannel_config` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
my recent pull request didn't change `playsms.sql` to reflect the new table schema, so it breaks on a clean installation.

this pull request fixes the situation.

I don't know the workflow of changes in plugins -- do I have bump a version number or something?
