### PR TITLE
Security fix: prevent use of special characters such as ; or /

### DIFF
--- a/web/plugin/feature/sms_command/fn.php
+++ b/web/plugin/feature/sms_command/fn.php
@@ -68,13 +68,15 @@ function sms_command_handle($c_uid,$sms_datetime,$sms_sender,$sms_receiver,$comm
 	if ($command_keyword && $command_exec && $username) {
 		$sms_datetime = core_display_datetime($sms_datetime);
 		$command_exec = str_replace("{SMSDATETIME}","\"$sms_datetime\"",$command_exec);
-		$command_exec = str_replace("{SMSSENDER}","\"$sms_sender\"",$command_exec);
-		$command_exec = str_replace("{COMMANDKEYWORD}","\"$command_keyword\"",$command_exec);
-		$command_exec = str_replace("{COMMANDPARAM}","\"$command_param\"",$command_exec);
-		$command_exec = str_replace("{COMMANDRAW}","\"$raw_message\"",$command_exec);
+		$command_exec = str_replace("{SMSSENDER}",escapeshellarg($sms_sender),$command_exec);
+		$command_exec = str_replace("{COMMANDKEYWORD}",escapeshellarg($command_keyword),$command_exec);
+		$command_exec = str_replace("{COMMANDPARAM}",escapeshellarg($command_param),$command_exec);
+		$command_exec = str_replace("{COMMANDRAW}",escapeshellarg($raw_message),$command_exec);
+		$command_exec = str_replace("/","",$command_exec);
 		$command_exec = $core_config['plugin']['sms_command']['bin']."/".$db_row['uid']."/".$command_exec;
-		logger_print("command_exec:".$command_exec, 3, "sms command");
-		$command_output = shell_exec(stripslashes($command_exec));
+		$command_exec = escapeshellcmd($command_exec);
+		logger_print("command_exec:".addslashes($command_exec), 3, "sms command");
+		$command_output = shell_exec($command_exec);
 		if ($command_return_as_reply == 1) {
 			$unicode = core_detect_unicode($command_output);
 			if ($command_output = addslashes(trim($command_output))) {


### PR DESCRIPTION
Prevent use of special characters such as ; or / in command,
which may be used to access server's system, to harm server's system.
In current trunk any user can
steal playsms database password,
download files from non-public directories,
remove logs,
erase hard disk data,
shutdown server, etc.

Also look at ae34b037063463cf255c6913da63b8be40a15705
which is to prevent regular users to create own commands
according to FAQ documentation,
all the same they should ask server administrator
to put command exec script to their personal directory
