### PR TITLE
Fix common action icons translations

### DIFF
--- a/web/plugin/themes/common/config.php
+++ b/web/plugin/themes/common/config.php
@@ -1,6 +1,12 @@
 <?php
 defined('_SECURE_') or die('Forbidden');
 
+if (function_exists('bindtextdomain')) {
+	bindtextdomain('messages', $apps_path['plug'].'/language/');
+	bind_textdomain_codeset('messages', 'UTF-8');
+	textdomain('messages');
+}
+
 // common action icons
 $core_config['icon']['add']		= "<span class='playsms-icon glyphicon glyphicon-plus' alt='"._('Add')."' title='"._('Add')."'></span>";
 $core_config['icon']['edit']		= "<span class='playsms-icon glyphicon glyphicon-cog' alt='"._('Edit')."' title='"._('Edit')."'></span>";


### PR DESCRIPTION
web/plugin/common has no own language files and all translations already exists in common language files,
but before including common icons the plugin's textdomain is connected.
This commit fixes translation of titles and descriptions of all common action icons.

Also if theme creator overrides icons in its config, then he also should add own icon description translations to theme's language file. Override icons example is commented out in current trunk and no need to add anything more.
