### PR TITLE
Fixed stopping of DAEMOND

### DIFF
--- a/daemon/linux/etc/playsms.init-centos
+++ b/daemon/linux/etc/playsms.init-centos
@@ -172,7 +172,7 @@ stop)
         fi
 
         printf "%-50s" "Stopping $DAEMOND"
-            PIDS=`cat $PIDFILED`
+            PIDD=`cat $PIDFILED`
             cd $DAEMON_PATH
         if [ -f $PIDFILED ]; then
             kill -HUP $PIDD


### PR DESCRIPTION
Stopping of DAEMOND failed because of wrong "PIDD" (was PIDS)
