### PR TITLE
Add custom logo using  as with old themes

### DIFF
--- a/web/plugin/themes/default/templates/page_forgot.html
+++ b/web/plugin/themes/default/templates/page_forgot.html
@@ -18,7 +18,7 @@
                                                        &nbsp;
                                                        <?php if (isset($theme_image)  &&  !empty($theme_image)) { ?>
                                                          <div align="center">
-							 <img style="vertical-align: bottom;" src="plugin/themes/play/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
+							 <img style="vertical-align: bottom;" src="plugin/themes/common/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
                                                          </div>
                                                        <?php } ?>
                                                </td>

--- a/web/plugin/themes/default/templates/page_login.html
+++ b/web/plugin/themes/default/templates/page_login.html
@@ -18,7 +18,7 @@
 							&nbsp;
 							<?php if (isset($theme_image)  &&  !empty($theme_image)) { ?>
 							  <div align="center">
-						          <img style="vertical-align: bottom;" src="plugin/themes/play/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
+						          <img style="vertical-align: bottom;" src="plugin/themes/common/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
 						          </div>
 						        <?php } ?>
 						</td>

--- a/web/plugin/themes/default/templates/page_register.html
+++ b/web/plugin/themes/default/templates/page_register.html
@@ -18,7 +18,7 @@
                                                        &nbsp;
                                                        <?php if (isset($theme_image)  &&  !empty($theme_image)) { ?>
                                                          <div align="center">
-                                                         <img style="vertical-align: bottom;" src="plugin/themes/play/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
+                                                         <img style="vertical-align: bottom;" src="plugin/themes/common/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
                                                          </div>
                                                        <?php } ?>
                                                </td>


### PR DESCRIPTION
I added the feature to use a custom logo in the front page, this feature was present in mostly the same way (using the same vars) in the old play theme.
To accomodate the logo I widened the login box 100px altough it's not strictly necessary.
If you wish I can adapt the other themes too.
