### PR TITLE
Add custom logo using the variable theme_image already present in old themes

### DIFF
--- a/web/plugin/themes/default/templates/page_forgot.html
+++ b/web/plugin/themes/default/templates/page_forgot.html
@@ -2,7 +2,7 @@
 	<tbody>
 	<tr>
 		<td align="center">
-		<table style='border-radius: 3px; background-color: #F0F0F0; width: 300px; padding: 10px;'>
+		<table style='border-radius: 3px; background-color: #F0F0F0; width: 400px; padding: 10px;'>
 			<tbody>
 			<tr>
 				<td>
@@ -13,8 +13,16 @@
 				<input type=hidden name=op value=auth_forgot>
 				<table width="80%" align="center">
 					<tbody>
-					<tr><td>&nbsp;</td></tr>
-					
+					<tr>
+                                               <td>
+                                                       &nbsp;
+                                                       <?php if (isset($theme_image)  &&  !empty($theme_image)) { ?>
+                                                         <div align="center">
+							 <img style="vertical-align: bottom;" src="plugin/themes/common/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
+                                                         </div>
+                                                       <?php } ?>
+                                               </td>
+                                       </tr>
 					<tr>
 						<td align="center">
 							<h1><a href={HTTP_PATH_BASE}>{WEB_TITLE}</a></h1>

--- a/web/plugin/themes/default/templates/page_login.html
+++ b/web/plugin/themes/default/templates/page_login.html
@@ -2,7 +2,7 @@
 	<tbody>
 	<tr>
 		<td align="center">
-		<table style='border-radius: 3px; background-color: #F0F0F0; width: 300px; padding: 10px;'>
+		<table style='border-radius: 3px; background-color: #F0F0F0; width: 400px; padding: 10px;'>
 			<tbody>
 			<tr>
 				<td>
@@ -13,7 +13,16 @@
 				<input type=hidden name=op value=auth_login>
 				<table width="80%" align="center">
 					<tbody>
-					<tr><td>&nbsp;</td></tr>
+					<tr>	
+						<td>
+							&nbsp;
+							<?php if (isset($theme_image)  &&  !empty($theme_image)) { ?>
+							  <div align="center">
+						          <img style="vertical-align: bottom;" src="plugin/themes/common/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
+						          </div>
+						        <?php } ?>
+						</td>
+					</tr>
 					
 					<tr>
 						<td align="center">

--- a/web/plugin/themes/default/templates/page_register.html
+++ b/web/plugin/themes/default/templates/page_register.html
@@ -2,7 +2,7 @@
 	<tbody>
 	<tr>
 		<td align="center">
-		<table style='border-radius: 3px; background-color: #F0F0F0; width: 300px; padding: 10px;'>
+		<table style='border-radius: 3px; background-color: #F0F0F0; width: 400px; padding: 10px;'>
 			<tbody>
 			<tr>
 				<td>
@@ -13,7 +13,16 @@
 				<input type=hidden name=op value=auth_register>
 				<table width="80%" align="center">
 					<tbody>
-					<tr><td>&nbsp;</td></tr>
+                                        <tr>
+                                               <td>
+                                                       &nbsp;
+                                                       <?php if (isset($theme_image)  &&  !empty($theme_image)) { ?>
+                                                         <div align="center">
+                                                         <img style="vertical-align: bottom;" src="plugin/themes/common/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
+                                                         </div>
+                                                       <?php } ?>
+                                               </td>
+                                       </tr>
 					
 					<tr>
 						<td align="center">


### PR DESCRIPTION
I added the feature to use a custom logo in the front page, this feature was present in mostly the same way (using the same vars) in the old play theme.
To accomodate the logo I widened the login box 100px altough it's not strictly necessary.
If you wish I can adapt the other themes too.
NOTE: It's the same pull request as #196, but with the commits properly squashed
