### PR TITLE
Add the option in config.php to enable an image in the three login pages...

### DIFF
--- a/web/config-dist.php
+++ b/web/config-dist.php
@@ -75,3 +75,6 @@ $core_config['sendsmsd_queue']	= 30;
 
 // webservices require username
 $core_config['webservices_username']	= true;
+
+// enable or disable custom logo
+$core_config['cfg_enable_logo']	= false;

--- a/web/plugin/themes/common/templates/page_forgot.html
+++ b/web/plugin/themes/common/templates/page_forgot.html
@@ -14,8 +14,16 @@
 				<input type=hidden name=op value=auth_forgot>
 				<table width="80%" align="center">
 					<tbody>
-					<tr><td>&nbsp;</td></tr>
-					
+                    <if.enable_logo>
+                        <tr>
+                            <td>
+                                &nbsp;
+                                <div align="center">
+                                    <img style="vertical-align: bottom;" src="plugin/themes/common/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
+                                </div>
+                            </td>
+                        </tr>
+                    </if.enable_logo>
 					<tr>
 						<td align="center">
 							<h1><a href={HTTP_PATH_BASE}>{WEB_TITLE}</a></h1>

--- a/web/plugin/themes/common/templates/page_login.html
+++ b/web/plugin/themes/common/templates/page_login.html
@@ -14,6 +14,16 @@
 				<input type=hidden name=op value=auth_login>
 				<table width="80%" align="center">
 					<tbody>
+                    <if.enable_logo>
+                        <tr>
+                            <td>
+                                &nbsp;
+                                    <div align="center">
+                                        <img style="vertical-align: bottom;" src="plugin/themes/common/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
+                                    </div>
+                            </td>
+                        </tr>
+                    </if.enable_logo>
 					<tr><td>&nbsp;</td></tr>
 					<tr>
 						<td align="center">

--- a/web/plugin/themes/common/templates/page_register.html
+++ b/web/plugin/themes/common/templates/page_register.html
@@ -14,8 +14,17 @@
 				<input type=hidden name=op value=auth_register>
 				<table width="80%" align="center">
 					<tbody>
-					<tr><td>&nbsp;</td></tr>
-					
+                    <if.enable_logo>
+                        <tr>
+                            <td>
+                                &nbsp;
+                                <div align="center">
+                                    <img style="vertical-align: bottom;" src="plugin/themes/common/images/default_logo.png" alt="<?php echo $theme_play_head1; ?>" >
+                                </div>
+                            </td>
+                        </tr>
+                    </if.enable_logo>
+
 					<tr>
 						<td align="center">
 							<h1><a href={HTTP_PATH_BASE}>{WEB_TITLE}</a></h1>

--- a/web/plugin/themes/default/page_forgot.php
+++ b/web/plugin/themes/default/page_forgot.php
@@ -16,7 +16,8 @@ $tpl = array(
 	'Register an account' => _('Register an account')
     ),
 	'if' => array(
-		'enable_register' => $core_config['main']['cfg_enable_register']
+		'enable_register' => $core_config['main']['cfg_enable_register'],
+        'enable_logo' => $core_config['cfg_enable_logo']
 	)
 );
 

--- a/web/plugin/themes/default/page_login.php
+++ b/web/plugin/themes/default/page_login.php
@@ -15,8 +15,9 @@ $tpl = array(
 		'Forgot password' => _('Forgot password')
 	),
 	'if' => array(
-		'enable_register' => $core_config['main']['cfg_enable_register'],
-		'enable_forgot' => $core_config['main']['cfg_enable_forgot']
+		'enable_register' => $core_config['cfg_enable_logo'],
+		'enable_forgot' => $core_config['main']['cfg_enable_forgot'],
+        'enable_logo' => $core_config['cfg_enable_logo']
 	)
 );
 

--- a/web/plugin/themes/default/page_register.php
+++ b/web/plugin/themes/default/page_register.php
@@ -18,7 +18,8 @@ $tpl = array(
 	'Forgot password' => _('Forgot password')
     ),
 	'if' => array(
-		'enable_forgot' => $core_config['main']['cfg_enable_forgot']
+		'enable_forgot' => $core_config['main']['cfg_enable_forgot'],
+        'enable_logo' => $core_config['cfg_enable_logo']
 	)
 );
 


### PR DESCRIPTION
... (login, forgot and register) in the default theme.

I used the main config.php for this, it doesn't need to be in the database IMHO, but maybe there's a better place to add the config.
