### PR TITLE
Add "format=PLAIN" to make webservices compatible with old api

### DIFF
--- a/web/inc/app/webservices.php
+++ b/web/inc/app/webservices.php
@@ -255,6 +255,10 @@ if ($format=='SERIALIZE') {
 	ob_end_clean();
 	header('Content-Type: text/xml');
 	_p($xml->asXML());
+} else if ($format=='PLAIN'){
+	ob_end_clean();
+	header('Content-Type: text/plain');
+	_p($json['status']." ".$json['error']);
 } else {
 	ob_end_clean();
 	header('Content-Type: application/json');


### PR DESCRIPTION
In older playsms versions the default webservices format was PLAIN, in the current versions the default and recommended usage is a json.
With this change we can output in the old format by passing "format=PLAIN" as a parameter
