### PR TITLE
Fix the upgrade of contact group data

### DIFF
--- a/db/playsms-upgrade-0992-to-100.sql
+++ b/db/playsms-upgrade-0992-to-100.sql
@@ -15,6 +15,10 @@ CREATE TABLE IF NOT EXISTS `playsms_toolsPhonebook_group_contacts` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+INSERT INTO `playsms_toolsPhonebook_group_contacts` (`id`,`gpid`,`pid`)
+  SELECT '',gpid,id  
+  FROM playsms_toolsPhonebook;
+
 ALTER TABLE `playsms_toolsPhonebook` DROP `gpid` ;
 
 -- core config


### PR DESCRIPTION
This fixes  the issue commented on the forum (https://groups.google.com/forum/#!topic/playsmsusergroup/G0GEsGy059c) preservin the phonebook groups after upgrade
