### PR TITLE
 * Fix #314

### DIFF
--- a/web/plugin/feature/incoming/fn.php
+++ b/web/plugin/feature/incoming/fn.php
@@ -330,9 +330,12 @@ function incoming_hook_recvsms_intercept($sms_datetime, $sms_sender, $message, $
 					} else if ($c_flag_sender == 1) {
 						
 						// check whether sms_sender belongs to c_group_code
-						$sms_sender = substr($sms_sender, 3);
-						$members = phonebook_search($c_uid, $sms_sender);
-						if (count($members) > 0) {
+						$db_query = "SELECT B.id AS id FROM " . _DB_PREF_ . "_featurePhonebook AS A
+								LEFT JOIN playsms.playsms_featurePhonebook_group_contacts AS C ON A.id=C.pid
+								LEFT JOIN playsms.playsms_featurePhonebook_group AS B ON B.id=C.gpid
+								WHERE A.mobile LIKE '%" . substr($sms_sender, 3) . "' AND B.code='" . $c_group_code . "'";
+						$db_result = dba_query($db_query);
+						if ($db_row = dba_fetch_array($db_result)) {
 							$c_username = user_uid2username($c_uid);
 							_log("bc mobile flag_sender:" . $c_flag_sender . " username:" . $c_username . " uid:" . $c_uid . " g:" . $c_group_code . " gpid:" . $c_gpid . " uid:" . $c_uid . " dt:" . $sms_datetime . " s:" . $sms_sender . " r:" . $sms_receiver . " m:" . $message, 3, 'incoming recvsms_intercept');
 							$sender = trim(phonebook_number2name($sms_sender, $c_username));

--- a/web/plugin/feature/phonebook/fn.php
+++ b/web/plugin/feature/phonebook/fn.php
@@ -78,7 +78,17 @@ function phonebook_hook_phonebook_number2name($mobile, $c_username = '') {
 			SELECT A.name AS name FROM " . _DB_PREF_ . "_featurePhonebook AS A
 			LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group_contacts AS C ON A.id=C.pid
 			LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group AS B ON B.id=C.gpid
-			WHERE ( A.mobile LIKE '%" . $mobile . "' AND A.uid='$uid' ) OR ( A.mobile LIKE '%" . $mobile . "' AND A.uid<>'$uid' AND B.flag_sender<>'0' ) LIMIT 1";
+			WHERE A.mobile LIKE '%" . $mobile . "' AND (
+				A.uid='$uid'
+				OR B.id in
+					(
+					SELECT B.id AS id FROM " . _DB_PREF_ . "_featurePhonebook AS A
+					LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group_contacts AS C ON A.id=C.pid
+					LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group AS B ON B.id=C.gpid
+					WHERE A.mobile='" . user_getfieldbyuid($uid, 'mobile') . "' AND B.flag_sender='1' 
+					)
+				OR ( A.uid<>'$uid' AND B.flag_sender>'1' ) )
+			LIMIT 1";
 		$db_result = dba_query($db_query);
 		$db_row = dba_fetch_array($db_result);
 		$name = $db_row['name'];
@@ -158,45 +168,66 @@ function phonebook_hook_phonebook_getgroupbyuid($uid, $orderby = "") {
 function phonebook_hook_phonebook_search($uid, $keyword = "", $count = 0) {
 	$ret = array();
 	if ($keyword) {
-		$fields = 'DISTINCT A.id AS pid, A.name AS p_desc, A.mobile AS p_num, A.email AS email';
-		$join = "LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group_contacts AS C ON A.id=C.pid ";
-		$join .= "LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group AS B ON B.id=C.gpid";
-		$conditions = array(
-			'( A.uid' => $uid."' OR B.flag_sender<>'0' ) AND '1'='1" 
-		);
-		$keywords = array(
-			'A.name' => '%' . $keyword . '%',
-			'A.mobile' => '%' . $keyword . '%',
-			'A.email' => '%' . $keyword . '%' 
-		);
+		$db_query = "
+			SELECT DISTINCT A.id AS pid, A.name AS p_desc, A.mobile AS p_num, A.email AS email
+			FROM " . _DB_PREF_ . "_featurePhonebook AS A
+                        LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group_contacts AS C ON A.id=C.pid
+                        LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group AS B ON B.id=C.gpid
+			WHERE (
+				A.uid='$uid' OR
+				B.id in (
+					SELECT B.id AS id FROM " . _DB_PREF_ . "_featurePhonebook AS A
+					LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group_contacts AS C ON A.id=C.pid
+					LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group AS B ON B.id=C.gpid
+					WHERE A.mobile='" . user_getfieldbyuid($uid, 'mobile') . "' AND B.flag_sender='1'
+				) OR (
+				A.uid <>'$uid' AND B.flag_sender>'1'
+				)
+			) AND (
+				A.name LIKE '%" . $keyword . "%' OR
+				A.mobile LIKE '%" . $keyword . "%' OR
+				A.email LIKE '%" . $keyword . "%'
+			)";
 		if ($count > 0) {
-			$extras = array(
-				'LIMIT' => $count 
-			);
+			$db_query .= " LIMIT " . $count;
 		}
-		$ret = dba_search(_DB_PREF_ . '_featurePhonebook AS A', $fields, $conditions, $keywords, $extras, $join);
+		$db_result = dba_query($db_query);
+		while ($db_row = dba_fetch_array($db_result)) {
+			$ret[] = $db_row;
+        	}
 	}
 	return $ret;
 }
 
 function phonebook_hook_phonebook_search_group($uid, $keyword = "", $count = 0) {
 	$ret = array();
-	$fields = 'DISTINCT id AS gpid, name AS group_name, code, flag_sender';
-	$conditions = array(
-		'( uid' => $uid."' OR flag_sender<>'0' ) AND '1'='1" 
-	);
+	$db_query = "
+		SELECT DISTINCT id AS gpid, name AS group_name, code, flag_sender
+		FROM " . _DB_PREF_ . "_featurePhonebook_group
+		WHERE (
+			uid='$uid' OR
+			id in (
+				SELECT B.id AS id FROM " . _DB_PREF_ . "_featurePhonebook AS A
+				LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group_contacts AS C ON A.id=C.pid
+				LEFT JOIN " . _DB_PREF_ . "_featurePhonebook_group AS B ON B.id=C.gpid
+				WHERE A.mobile='" . user_getfieldbyuid($uid, 'mobile') . "' AND B.flag_sender='1'
+			) OR (
+			uid <>'$uid' AND flag_sender>'1'
+			)
+		)";
 	if ($keyword) {
-		$keywords = array(
-			'name' => '%' . $keyword . '%',
-			'code' => '%' . $keyword . '%' 
-		);
+		$db_query .= " AND (
+					name LIKE '%" . $keyword . "%' OR
+					code LIKE '%" . $keyword . "%'
+					)";
 	}
 	if ($count > 0) {
-		$extras = array(
-			'LIMIT' => $count 
-		);
+		$db_query .= " LIMIT " . $count;
 	}
-	$ret = dba_search(_DB_PREF_ . '_featurePhonebook_group', $fields, $conditions, $keywords, $extras);
+	$db_result = dba_query($db_query);
+	while ($db_row = dba_fetch_array($db_result)) {
+		$ret[] = $db_row;
+	}
 	return $ret;
 }
 

--- a/web/plugin/feature/phonebook/phonebook.php
+++ b/web/plugin/feature/phonebook/phonebook.php
@@ -20,7 +20,12 @@ switch (_OP_) {
 		$join = 'LEFT JOIN ' . _DB_PREF_ . '_featurePhonebook_group_contacts AS C ON A.id=C.pid ';
 		$join .= 'LEFT JOIN ' . _DB_PREF_ . '_featurePhonebook_group AS B ON B.id=C.gpid';
 		$conditions = array(
-			'( A.uid' => $user_config['uid']."' OR B.flag_sender<>'0' ) AND '1'='1"
+			'( A.uid' => $user_config['uid'] . "' OR B.id in (
+									SELECT B.id AS id FROM " . _DB_PREF_ . "_featurePhonebook AS A
+									" . $join . "
+									WHERE A.mobile='" . $user_config['mobile'] . "'
+									AND B.flag_sender='1'
+									) OR ( A.uid <>'" . $user_config['uid'] . "' AND B.flag_sender>'1' ) ) AND '1'='1"
 		);
 		$keywords = $search['dba_keywords'];
 		$count = dba_count(_DB_PREF_ . '_featurePhonebook AS A', $conditions, $keywords, '', $join);
@@ -32,9 +37,9 @@ switch (_OP_) {
 		);
 		$list = dba_search(_DB_PREF_ . '_featurePhonebook AS A', $fields, $conditions, $keywords, $extras, $join);
 		
-		$phonebook_groups = phonebook_search_group($user_config['uid']);
+		$phonebook_groups = phonebook_getgroupbyuid($user_config['uid']);
 		foreach ($phonebook_groups as $group ) {
-			$action_move_options .= '<option value=move_' . $group['gpid'] . '>' . _('Move to') . ' ' . $group['group_name'] . ' (' . $group['code'] . ')</option>';
+			$action_move_options .= '<option value=move_' . $group['gpid'] . '>' . _('Move to') . ' ' . $group['gp_name'] . ' (' . $group['gp_code'] . ')</option>';
 		}
 		
 		$content = "
@@ -90,8 +95,13 @@ switch (_OP_) {
 			$group_code = "";
 			$groupfields = 'B.id AS id, B.uid AS uid, B.code AS code, B.flag_sender AS flag_sender';
 			$groupconditions = array(
-				'B.uid' => $user_config['uid'],
-				'C.pid' => $list[$j]['pid']."' OR ( B.uid<>'".$user_config['uid']."' AND C.pid='".$list[$j]['pid']."' AND B.flag_sender<>'0' ) AND '1'='1" 
+				'C.pid' => $list[$j]['pid'],
+				'( B.uid' => $user_config['uid'] . "' OR B.id in (
+										SELECT B.id AS id FROM " . _DB_PREF_ . "_featurePhonebook AS A
+										" . $join . "
+										WHERE A.mobile='" . $user_config['mobile'] . "'
+										AND B.flag_sender='1'
+										) OR ( B.uid<>'" . $user_config['uid'] . "' AND B.flag_sender>'1' ) ) AND '1'='1" 
 			);
 			$groupextras = array(
 				'ORDER BY' => 'B.code ASC',
@@ -217,7 +227,12 @@ switch (_OP_) {
 				$join = 'LEFT JOIN ' . _DB_PREF_ . '_featurePhonebook_group_contacts AS C ON A.id = C.pid ';
 				$join .= 'LEFT JOIN ' . _DB_PREF_ . '_featurePhonebook_group AS B ON B.id = C.gpid';
 				$conditions = array(
-					'( A.uid' => $user_config['uid']."' OR B.flag_sender<>'0' ) AND '1'='1"
+					'( A.uid' => $user_config['uid'] . "' OR B.id in (
+											SELECT B.id AS id FROM " . _DB_PREF_ . "_featurePhonebook AS A
+											" . $join . "
+											WHERE A.mobile='" . $user_config['mobile'] . "'
+											AND B.flag_sender='1'
+											) OR ( A.uid <>'" . $user_config['uid'] . "' AND B.flag_sender>'1' ) ) AND '1'='1"
 				);
 				$keywords = $search['dba_keywords'];
 				$extras = array(

--- a/web/plugin/feature/phonebook/phonebook_go.php
+++ b/web/plugin/feature/phonebook/phonebook_go.php
@@ -42,7 +42,7 @@ if ($gpid && (dba_valid(_DB_PREF_ . '_featurePhonebook_group', 'id', $gpid))) {
 	foreach ($items as $item ) {
 		if (dba_remove(_DB_PREF_ . '_featurePhonebook_group_contacts', array(
 			'pid' => $item 
-		))) {
+		)) or !dba_valid(_DB_PREF_ . '_featurePhonebook_group_contacts', 'pid', $item )) {
 			$data = array(
 				'pid' => $item,
 				'gpid' => $gpid 


### PR DESCRIPTION
- Fix #314
  Now users can view and search:
  - own contacts and groups,
  - contacts owned by other users in groups shared for members if user's mobile number matches a member of that group,
  - and also all contacts in groups shared for anyone
- Fix "move to group" list
  "Move to group" list should contain only own groups
- Fix "move to group" command for contacts that is not in any group yet
  
  Now contacts without groups correctly moving by menu command
- Fix check for members visibility at incoming processing
  
  Now really checking whether sms sender belongs to group code if flag_sender is 1 (Members)
