### PR TITLE
Small phonebook fixes.

### DIFF
--- a/web/plugin/feature/phonebook/group.php
+++ b/web/plugin/feature/phonebook/group.php
@@ -238,7 +238,7 @@ switch (_OP_) {
 						
 						// check whether or not theres a group code with the same name and flag_sender <> 0
 						if ($flag_sender > 0) {
-							$db_query = "SELECT flag_sender FROM " . _DB_PREF_ . "_featurePhonebook_group WHERE code='$group_code' AND flag_sender<>0";
+							$db_query = "SELECT flag_sender FROM " . _DB_PREF_ . "_featurePhonebook_group WHERE code='$group_code' AND flag_sender<>0 AND NOT id='$gpid'";
 							$db_result = dba_query($db_query);
 							if ($db_row = dba_fetch_array($db_result)) {
 								$flag_sender = 0;

--- a/web/plugin/feature/phonebook/phonebook_go.php
+++ b/web/plugin/feature/phonebook/phonebook_go.php
@@ -58,15 +58,18 @@ if (($ops[0] == 'move') && $ops[1]) {
 
 if ($gpid && (dba_valid(_DB_PREF_ . '_featurePhonebook_group', 'id', $gpid))) {
 	foreach ($items as $item) {
-		if (dba_remove(_DB_PREF_ . '_featurePhonebook_group_contacts', array(
-			'pid' => $item 
-		)) or !dba_valid(_DB_PREF_ . '_featurePhonebook_group_contacts', 'pid', $item)) {
-			$data = array(
-				'pid' => $item,
-				'gpid' => $gpid 
-			);
-			if (dba_add(_DB_PREF_ . '_featurePhonebook_group_contacts', $data)) {
-				$_SESSION['error_string'] = _('Selected contact moved to new group');
+		if (dba_valid(_DB_PREF_ . '_featurePhonebook', 'id', $item)) {
+			if (dba_remove(_DB_PREF_ . '_featurePhonebook_group_contacts', array(
+				'pid' => $item 
+			)) or dba_isavail(_DB_PREF_ . '_featurePhonebook_group_contacts', array(
+				'pid' => $item ))) {
+				$data = array(
+					'pid' => $item,
+					'gpid' => $gpid 
+				);
+				if (dba_add(_DB_PREF_ . '_featurePhonebook_group_contacts', $data)) {
+					$_SESSION['error_string'] = _('Selected contact moved to new group');
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Fix error when changing visibility level on "edit group" page.
  When trying to update visibility level we should check for other shared groups with same code,
  but script was mistakenly checked for the same group exists and update fails, this patch fixes it.
- User should be able to move to groups only own contacts
  Added dba_valid check for contact before moving it, this function has uid check for non-admin users,
  so users can't anymore move others shared contacts from others shared groups to their own groups.
  This is mostly a security permissions patch.
- Changed check for contact not in any group when moving to group using more suitable function.
