### PR TITLE
On mouseover titles to status icons

### DIFF
--- a/web/plugin/feature/report/user_outgoing.php
+++ b/web/plugin/feature/report/user_outgoing.php
@@ -97,13 +97,13 @@ switch (_OP_) {
 			// 2 = failed
 			// 3 = delivered
                         if ($p_status == "1") {
-                                $p_status = "<span class=status_sent title='sent'/>";
+                                $p_status = "<span class=status_sent title='". _('Sent') ."'/>";
                         } else if ($p_status == "2") {
-                                $p_status = "<span class=status_failed title='failed'/>";
+                                $p_status = "<span class=status_failed title='". _('Failed') ."'/>";
                         } else if ($p_status == "3") {
-                                $p_status = "<span class=status_delivered title='delivered'/>";
+                                $p_status = "<span class=status_delivered title='". _('Delivered') ."'/>";
                         } else {
-                                $p_status = "<span class=status_pending title='pending'/>";
+                                $p_status = "<span class=status_pending title='". _('Pending') ."'/>";
                         }
                         $p_status = strtolower($p_status);
 			


### PR DESCRIPTION
Simple titles on mouse-over the status icons on message status so users can read the status corresponding to colors.
