### PR TITLE
Prevent accidental template reset

### DIFF
--- a/storage/application/plugin/core/sendsms/templates/sendsms.html
+++ b/storage/application/plugin/core/sendsms/templates/sendsms.html
@@ -129,7 +129,7 @@
 			}
 		});
 
-		$("#{{ SENDSMS_FORM_ID }} select[name='smstemplate']").on('click', function() {
+		$("#{{ SENDSMS_FORM_ID }} select[name='smstemplate']").on('change', function() {
 			SetSmsTemplate('{{ SENDSMS_FORM_ID }}');
 		});
 


### PR DESCRIPTION
Clicking on the select, at all, even if you don't change the value, reverts all edits to the message being composed. It should listen to the change event.