### PR TITLE
Update fn.php - PHP 8 compatibility

### DIFF
--- a/storage/application/plugin/core/sendmail/fn.php
+++ b/storage/application/plugin/core/sendmail/fn.php
@@ -111,7 +111,7 @@ function sendmail($data = array())
 		$mail->Host = ($smtp_host ? $smtp_host : _SMTP_HOST_); // Set the SMTP server to send through
 		$mail->Port = ($smtp_port ? $smtp_port : _SMTP_PORT_); // TCP port to connect to, use 465 for `PHPMailer::ENCRYPTION_SMTPS` above
 
-		if ($smtp_user) {
+		if ($smtp_user !== '') {
 			$mail->SMTPAuth = true; // Enable SMTP authentication
 			$mail->Username = ($smtp_user ? $smtp_user : _SMTP_USER_); // SMTP username
 			$mail->Password = ($smtp_pass ? $smtp_pass : _SMTP_PASS_); // SMTP password


### PR DESCRIPTION
Since version 8 of PHP, the syntax `$string == true` always returns `false`. This means that even if everything is set up correctly, it will not work. Therefore, it is necessary to replace this check with a comparison against an empty string. This should work well with earlier versions of PHP as well.