### PR TITLE
Show disabled plugins as such

### DIFF
--- a/web/plugin/feature/pluginmanager/fn.php
+++ b/web/plugin/feature/pluginmanager/fn.php
@@ -22,12 +22,14 @@ function _pluginmanager_get_status($plugin_category, $name)
 {
 	$ret = false;
 
-	if ($plugin_category == "themes") {
-		$ret = core_themes_get() == $name ? true : false;
-	} else if ($plugin_category == "language") {
-		$ret = core_lang_get() == $name ? true : false;
-	} else {
-		$ret = true;
+	if ($name[0] != '.') {
+		if ($plugin_category == "themes") {
+			$ret = core_themes_get() == $name;
+		} else if ($plugin_category == "language") {
+			$ret = core_lang_get() == $name;
+		} else {
+			$ret = true;
+		}
 	}
 
 	return $ret;


### PR DESCRIPTION
`lib/function.php` does not load plugins disabled by a `.` prefix on their dir name but the manager shows them as enabled.