### PR TITLE
Delivery status issues

### DIFF
--- a/web/lib/fn_dlr.php
+++ b/web/lib/fn_dlr.php
@@ -58,6 +58,10 @@ function dlrd()
 {
 	global $core_config;
 
+	if (!$core_config['isdlrd']) {
+		return;
+	}
+
 	$c_dlrd_limit = (int) $core_config['dlrd_limit'] > 0 ? (int) $core_config['dlrd_limit'] : 1000;
 	$db_query = "SELECT id, smslog_id, p_status, uid FROM " . _DB_PREF_ . "_tblDLR WHERE flag_processed=1 LIMIT " . $c_dlrd_limit;
 	$db_result = dba_query($db_query);


### PR DESCRIPTION
I found that when `dlrd` was disabled, it would still do a lot of data processing, the short circuit dealt with that part.

I switched the file check to a glob to simplify the test for presence.

I also found that when it was checking if some messages were processed it never cleared them because it kept comparing two timestamps, expecting them to get further apart, but one never changed, and the other didn't change until after `dlr()` gets called. From what I could tell, that function isn't called until after the message has failed or sent, so it was a catch-22, and never marked any as old.

This needs further review to ensure I haven't misunderstood.
