### PR TITLE
SMS with 30 char footer are not sent.

### DIFF
--- a/web/plugin/core/sendsms/fn.php
+++ b/web/plugin/core/sendsms/fn.php
@@ -457,6 +457,7 @@ function sendsms_process($smslog_id, $sms_sender, $sms_footer, $sms_to, $sms_msg
 	// $sms_sender = core_sanitize_mobile($sms_sender);
 
 	// fixme anton - add a space in front of $sms_footer
+	$orig_sms_footer = $sms_footer;
 	if (trim($sms_footer)) {
 		$sms_footer = ' ' . trim($sms_footer);
 	}
@@ -496,7 +497,7 @@ function sendsms_process($smslog_id, $sms_sender, $sms_footer, $sms_to, $sms_msg
 		$smsc,
 		$sms_sender,
 		$sms_to,
-		$sms_footer,
+		$orig_sms_footer,
 		$sms_msg,
 		$sms_datetime,
 		$p_status,


### PR DESCRIPTION
If footer is set to exactly 30 chars (maximum in other db fields), the sendsms_process function adds space, before attempting to write to tblSMSOutgoing, resulting in 31 chars, which throws an error:

`_dba_execute # Exception: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'p_footer' at row 1`