### PR TITLE
Prevent inclusion of init.php multiple times

### DIFF
--- a/web/init.php
+++ b/web/init.php
@@ -16,6 +16,9 @@
  * You should have received a copy of the GNU General Public License
  * along with playSMS. If not, see <http://www.gnu.org/licenses/>.
  */
+
+if (defined('INCLUDE_INIT_PHP')) return; define('INCLUDE_INIT_PHP',1);
+
 if (is_file('config.php')) {
 	require 'config.php';
 } else {


### PR DESCRIPTION
Issue https://github.com/playsms/playsms/issues/684

Credit not being added because list of plugins in daemon is empty due to the inclusion of init.php multiple times.
init.php does not read plugins; it only initializes plugin categories, so including it again at later point does clear the list of plugins.

