### PR TITLE
Fix error when sending SMS through Jasmin gateway

### DIFF
--- a/web/plugin/gateway/jasmin/fn.php
+++ b/web/plugin/gateway/jasmin/fn.php
@@ -86,7 +86,7 @@ function jasmin_hook_sendsms($smsc, $sms_sender, $sms_footer, $sms_to, $sms_msg,
 			if ($remote_id) {
 				_log("sent smslog_id:" . $smslog_id . " remote_id:" . $remote_id . " smsc:" . $smsc, 2, "jasmin_hook_sendsms");
 
-				if (dba_update(_DB_PREF_ . '_playsms_tblSMSOutgoing', ['remote_id' => $remote_id], ['smslog_id' => $smslog_id, 'flag_deleted' => 0])) {
+				if (dba_update(_DB_PREF_ . '_tblSMSOutgoing', ['remote_id' => $remote_id], ['smslog_id' => $smslog_id, 'flag_deleted' => 0])) {
 					$p_status = 1;
 					dlr($smslog_id, $uid, $p_status);
 


### PR DESCRIPTION
L2 _dba_execute # Exception: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'playsms.playsms_playsms_tblSMSOutgoing' doesn't exist