### PR TITLE
Fix smsc config loading for jasmin callback

### DIFF
--- a/web/plugin/gateway/jasmin/callback.php
+++ b/web/plugin/gateway/jasmin/callback.php
@@ -41,6 +41,9 @@ if ($remote_id && $status) {
 	$smsc = isset($_REQUEST['origin-connector']) ? $_REQUEST['origin-connector'] : ''; // SMSC in incoming SMS push
 }
 
+// Jasmin 0.11 will send it's own IDs in id/connector, thus we need to pass smsc name
+if (isset($_REQUEST['smsc'])) $smsc = $_REQUEST['smsc'];
+
 $authcode = isset($_REQUEST['authcode']) && trim($_REQUEST['authcode']) ? trim($_REQUEST['authcode']) : '';
 
 // validate authcode

--- a/web/plugin/gateway/jasmin/fn.php
+++ b/web/plugin/gateway/jasmin/fn.php
@@ -63,8 +63,12 @@ function jasmin_hook_sendsms($smsc, $sms_sender, $sms_footer, $sms_to, $sms_msg,
 			}
 		}
 
-		$callback_url = isset($plugin_config['jasmin']['callback_authcode']) && $plugin_config['jasmin']['callback_authcode']
-			? $plugin_config['jasmin']['callback_url'] . "?authcode=" . $plugin_config['jasmin']['callback_authcode'] : $plugin_config['jasmin']['callback_url'];
+		$callback_args = [];
+		if (isset($plugin_config['jasmin']['callback_authcode']) && $plugin_config['jasmin']['callback_authcode']) {
+			$callback_args['authcode']=$plugin_config['jasmin']['callback_authcode'];
+		}
+		$callback_args['smsc'] = $smsc;
+		$callback_url = $plugin_config['jasmin']['callback_url'].'?'.http_build_query($callback_args);
 
 		$query_string = "username=" . urlencode($plugin_config['jasmin']['api_username']) . "&password=" . urlencode($plugin_config['jasmin']['api_password']);
 		$query_string .= "&to=" . urlencode($sms_to) . "&from=" . urlencode($sms_sender) . "&content=" . urlencode($sms_msg) . $unicode_query_string;


### PR DESCRIPTION
Fix jasmin callback, because jasmin puts it's own ids in connector, thus plugin config by smsc name is never loaded.